### PR TITLE
Add opportunity of custom reply markup for Telegram

### DIFF
--- a/src/services/Telegram.service.js
+++ b/src/services/Telegram.service.js
@@ -134,6 +134,13 @@ export default class Telegram extends Template {
           text: ['```'].concat(buttons.map(({ title, value }) => `${value} - ${title}`)).concat('```').join('\n'),
         })),
       }
+    case 'customMarkup':
+      return {
+          ...reply,
+          type: 'customMarkup',
+          body: _.get(content, 'text'),
+          keyboard: _.get(content, 'markup'),
+      }
     default:
       throw new BadRequestError('Message type non-supported by Telegram')
     }
@@ -159,6 +166,8 @@ export default class Telegram extends Template {
       for (const elem of body) {
         await agent.post(`${url}/sendMessage`, { chat_id: to, text: elem, parse_mode: 'Markdown' })
       }
+    } else if (type === 'customMarkup') {
+        await agent.post(`${url}/sendMessage`, { chat_id: to, text: body, reply_markup: keyboard, parse_mode: 'Markdown' })
     } else {
       await agent.post(`${url}/${method}`, { chat_id: to, [type]: body })
     }


### PR DESCRIPTION
I'm developing AI bot based on your service but I ran into problem of bot-connector API incompleteness.
For example i cannot request user's phone number and cannot use "inline" buttons
I added opportunity of sending custom reply markup
Will be cool if you approve my pull request